### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-##As of July 28, 2013, the Aviary Android SDK will no longer be distributed via GitHub. Please visit http://www.aviary.com/android to download the latest version.
+## As of July 28, 2013, the Aviary Android SDK will no longer be distributed via GitHub. Please visit http://www.aviary.com/android to download the latest version.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
